### PR TITLE
change the default password reset email address

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,6 +92,7 @@ config.action_mailer.smtp_settings = {
   
   config.action_mailer.default_url_options = {
     host: 'walrus-app-bfv5e.ondigitalocean.app',
-    protocol: 'https'
+    protocol: 'https',
+    from: 'no-reply@farmspheredynamics.com'
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,8 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = {
     host: 'walrus-app-bfv5e.ondigitalocean.app',
-    protocol: 'https'
+    protocol: 'https',
+    from: 'no-reply@farmspheredynamics.com'
   }
 
   config.action_mailer.perform_caching = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'donotreply@example.com'
+  config.mailer_sender = 'no-reply@farmspheredynamics.com'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
this commit changes the default email address from an @example.com domain because mailtrap automatically blocks these addresses.