### PR TITLE
change the default domain back to farmspheredymaics

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -93,6 +93,6 @@ config.action_mailer.smtp_settings = {
   config.action_mailer.default_url_options = {
     host: 'walrus-app-bfv5e.ondigitalocean.app',
     protocol: 'https',
-    from: 'no-reply@mailtrap.io'
+    from: 'no-reply@farmspheredynamics.com'
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: 'walrus-app-bfv5e.ondigitalocean.app',
     protocol: 'https',
-    from: 'no-reply@mailtrap.io'
+    from: 'no-reply@farmspheredynamics.com'
   }
 
   config.action_mailer.perform_caching = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'no-reply@mailtrap.io'
+  config.mailer_sender = 'no-reply@farmspheredynamics.com'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
this commit will change the default domain back to farmspheredynamics as it has now been verified in mailtrap