### PR TITLE
add another link in the mailer that the user can copy and paste

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,13 @@
 <p>Hello <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>Someone has requested a link to change your password though the FarmBoard Application. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token, only_path: false).sub(/\/password/, '/--/password') %></p>
+<p>
+  <%= link_to 'Change my password', "farmboard://--/password/edit?token=#{@token}" %>
+</p>
+
+<p>If the link is not clickable, copy and paste this into your browser or into your iOS device:</p>
+<p>farmboard://--/password/edit?token=<%= @token %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,16 +38,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.delivery_method = :smtp
-config.action_mailer.smtp_settings = {
-  :user_name => '91b26688fbe7f8',
-  :password => '228d48ef8ca5ca',
-  :address => 'sandbox.smtp.mailtrap.io',
-  :host => 'sandbox.smtp.mailtrap.io',
-  :port => '2525',
-  :authentication => :login
-}
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
this commit adds another link that the user can copy and paste, because gmail does not recognize the redirect as a valid link.