### PR TITLE
add cover image route for guest view

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
         member do
           get :gallery_photos
           get :cover_photo
+          get :user_image
         end
       end
     end


### PR DESCRIPTION
this commit un-nests the cover image route so that we can access the user image of a marketplace posting in guest mode